### PR TITLE
Hide project structure menu option

### DIFF
--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -24,7 +24,8 @@
         <item
             android:id="@+id/nav_project_structure"
             android:icon="@drawable/ic_folder"
-            android:title="Proje Yapısını Çıkar" />
+            android:title="Proje Yapısını Çıkar"
+            android:visible="false" />
     </group>
 
     <item android:title="Diğer">


### PR DESCRIPTION
## Summary
- hide the Project Structure navigation drawer item so it no longer appears in the UI

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257b37e0d4832e8a0d7011e501588b)