### PR TITLE
Fix image attachments being cleared before send

### DIFF
--- a/app/src/main/java/com/aikodasistani/aikodasistani/MainActivity.kt
+++ b/app/src/main/java/com/aikodasistani/aikodasistani/MainActivity.kt
@@ -2042,6 +2042,7 @@ class MainActivity : AppCompatActivity(),
 
             } else if (text.isNotEmpty() || pendingImageBase64List.isNotEmpty()) {
                 val messageToSend = if (text.isNotEmpty()) text else "Bu görseli analiz et"
+                val imagesToSend = pendingImageBase64List.toList()
 
                 Log.d("SEND_DEBUG", "Normal mesaj gönderiliyor: ${messageToSend.take(50)}...")
 
@@ -2049,9 +2050,9 @@ class MainActivity : AppCompatActivity(),
 
                 // ✅ KADEMELİ derin düşünme çağrısı
                 if (currentThinkingLevel > 0) {
-                    getRealDeepThinkingResponse(messageToSend, pendingImageBase64List)
+                    getRealDeepThinkingResponse(messageToSend, imagesToSend)
                 } else {
-                    getRealAiResponse(messageToSend, pendingImageBase64List, false)
+                    getRealAiResponse(messageToSend, imagesToSend, false)
                 }
 
                 editTextMessage.text.clear()


### PR DESCRIPTION
## Summary
- preserve selected image attachments by copying them before clearing the pending list
- ensure deep thinking and normal responses receive uploaded images even when no text is provided

## Testing
- ./gradlew test *(fails: unable to download Gradle due to proxy 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d289e350832eb66ddeb6701aed30)